### PR TITLE
DependabotにDockerとDev Containers監視を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,4 +32,34 @@ updates:
     ignore:
       # メジャーアップデートは自動更新しない
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"] 
+        update-types: ["version-update:semver-major"]
+
+  # Dockerの依存関係を維持する
+  - package-ecosystem: "docker"
+    directory: "/docker/app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
+  # Dev Containersの依存関係を維持する
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "dependencies"
+      - "devcontainers"
+    commit-message:
+      prefix: "build"
+      include: "scope" 


### PR DESCRIPTION
## Summary
- Docker依存関係の監視設定を追加（/docker/app）
- Dev Containers依存関係の監視設定を追加（/.devcontainer）
- 週次月曜日9時JSTでの自動更新に統一

## Test plan
- [x] YAML構文の検証完了
- [x] 設定ファイルの内容確認完了
- [ ] GitHubでDependabotが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

## Issue

https://github.com/impala-inc/rails-boilerplate/issues/32