### PR TITLE
fix: Dev Containersの監視ディレクトリを修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,7 +51,7 @@ updates:
 
   # Dev Containersの依存関係を維持する
   - package-ecosystem: "devcontainers"
-    directory: "/.devcontainer"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
- Dev Containersの`directory`設定を`/.devcontainer`から`/`に修正
- Dependabotが"dependency files not found"エラーを解決

## 問題
- Dev Containers用のDependabot設定で依存関係ファイルが見つからないエラーが発生
- `directory: "/.devcontainer"`の設定が原因

## 解決策
- [containers.dev/guide/dependabot](https://containers.dev/guide/dependabot)のドキュメントに従い
- `directory: "/"`に変更してルートディレクトリから自動検出させる

## Test plan
- [x] YAML構文の検証完了
- [ ] GitHubでDependabotのエラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)